### PR TITLE
Fix configure-lisp for implementations not in the built-in table

### DIFF
--- a/src/backend.lisp
+++ b/src/backend.lisp
@@ -60,10 +60,10 @@
           (when eval-arg (setf (getf plist :eval-arg) eval-arg))
           (setf (rest entry) plist))
         ;; Add new entry
-        (push (list* impl
-                     :program (or program (string-downcase (symbol-name impl)))
-                     :args args
-                     :eval-arg (or eval-arg "--eval"))
+        (push (list impl
+                    :program (or program (string-downcase (symbol-name impl)))
+                    :args args
+                    :eval-arg (or eval-arg "--eval"))
               *lisp-implementations*))
     impl))
 


### PR DESCRIPTION
ICL works great with Clamiga. Yet had to make an adjustment.

AI generated comment:

The add-new-entry path built the plist with list*, leaving a dotted tail (:eval-arg . "--eval"), so the first getf on the entry signaled "malformed property list" — registering any Lisp outside *lisp-implementations* (e.g. (icl:configure-lisp :clamiga ...) in ~/.iclrc) crashed at startup. Use list.